### PR TITLE
fix: anti-pattern "not" for list

### DIFF
--- a/src/raw/_internal.py
+++ b/src/raw/_internal.py
@@ -22,7 +22,7 @@ class _bot_callbacks:
     async def _call_callbacks(self, callback_id, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
-        if not callback_id in self.callbacks.keys():
+        if callback_id not in self.callbacks.keys():
             return
 
         not_awaited = []


### PR DESCRIPTION
Replace not callback_id in with callback_id not in _____

Signed-off-by: Kenneth Sequeira <33246109+kennethsequeira@users.noreply.github.com>

[Reference issue](https://deepsource.io/gh/MeowerBots/MeowerBot.py/issue/FLK-E713/occurrences?listindex=0)